### PR TITLE
[Fix]customer_homes_controller

### DIFF
--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -1,5 +1,5 @@
 class Public::HomesController < ApplicationController
-  before_action :authenticate_user!, except: [:top]
+  before_action :authenticate_customer!, except: [:top, :about]
 
   def top
     @new_item = Item.order(created_at: :desc).limit(4)


### PR DESCRIPTION
ログアウト時のアバウトページへのアクセス制限を解除